### PR TITLE
first working version with fixed parameters

### DIFF
--- a/cupix/likelihood/minimize_posterior.py
+++ b/cupix/likelihood/minimize_posterior.py
@@ -91,7 +91,7 @@ class Minimizer(object):
                 self.minimizer.hesse()
 
 
-    def get_best_fit_params(self):
+    def get_best_fit_params(self, add_fixed_params):
         """Run minimizer if needed, return dictionary"""
 
         # make sure you have run the minimizer
@@ -100,8 +100,11 @@ class Minimizer(object):
         # get best-fit values from minimizer (should check this is really the best-fit)
         best_fit_values = self.minimizer.values 
 
-        # transform to dictionary of parameters
-        best_fit_params = self.post.get_params_from_values(best_fit_values)
+        # transform to dictionary of parameters (might add fixed params)
+        best_fit_params = self.post.get_params_from_values(
+                values=best_fit_values,
+                add_fixed_params=add_fixed_params
+        )
 
         return best_fit_params
 
@@ -110,7 +113,7 @@ class Minimizer(object):
         """Compute chi2 for best-fit parameters (will minimize if needed)"""
 
         # get best-fit parameters (will run minimizer if needed)
-        best_fit_params = self.get_best_fit_params()
+        best_fit_params = self.get_best_fit_params(add_fixed_params=True)
 
         # ask likelihood for chi2
         return self.post.like.get_chi2(params=best_fit_params, return_info=return_info)
@@ -118,7 +121,7 @@ class Minimizer(object):
 
     def get_best_fit_probability(self):
         # get best-fit parameters (will run minimizer if needed)
-        best_fit_params = self.get_best_fit_params()
+        best_fit_params = self.get_best_fit_params(add_fixed_params=True)
         n_free_p = len(self.post.free_params)
         return self.post.like.get_probability(best_fit_params, n_free_p=n_free_p)
 
@@ -241,7 +244,7 @@ class Minimizer(object):
         """Plot best-fit PX vs data."""
 
         # obtain dictionary of best-fit parameters (will minimize if needed)
-        best_fit_params = self.get_best_fit_params()
+        best_fit_params = self.get_best_fit_params(add_fixed_params=True)
 
         # use plotting tool in likelihood object to plot data and theory
         self.post.like.plot_px(

--- a/cupix/likelihood/minimize_posterior.py
+++ b/cupix/likelihood/minimize_posterior.py
@@ -91,7 +91,7 @@ class Minimizer(object):
                 self.minimizer.hesse()
 
 
-    def get_best_fit_params(self, add_fixed_params):
+    def get_best_fit_params(self):
         """Run minimizer if needed, return dictionary"""
 
         # make sure you have run the minimizer
@@ -100,11 +100,8 @@ class Minimizer(object):
         # get best-fit values from minimizer (should check this is really the best-fit)
         best_fit_values = self.minimizer.values 
 
-        # transform to dictionary of parameters (might add fixed params)
-        best_fit_params = self.post.get_params_from_values(
-                values=best_fit_values,
-                add_fixed_params=add_fixed_params
-        )
+        # transform to dictionary of parameters
+        best_fit_params = self.post.get_params_from_values(best_fit_values)
 
         return best_fit_params
 
@@ -113,17 +110,25 @@ class Minimizer(object):
         """Compute chi2 for best-fit parameters (will minimize if needed)"""
 
         # get best-fit parameters (will run minimizer if needed)
-        best_fit_params = self.get_best_fit_params(add_fixed_params=True)
+        params = self.get_best_fit_params()
+
+        # add fixed parameters in the posterior
+        params.update(self.post.fixed_params)
 
         # ask likelihood for chi2
-        return self.post.like.get_chi2(params=best_fit_params, return_info=return_info)
+        return self.post.like.get_chi2(params=params, return_info=return_info)
 
 
     def get_best_fit_probability(self):
+
         # get best-fit parameters (will run minimizer if needed)
-        best_fit_params = self.get_best_fit_params(add_fixed_params=True)
-        n_free_p = len(self.post.free_params)
-        return self.post.like.get_probability(best_fit_params, n_free_p=n_free_p)
+        params = self.get_best_fit_params()
+        n_free_p = len(params)
+
+        # add fixed parameters in the posterior
+        params.update(self.post.fixed_params)
+
+        return self.post.like.get_probability(params, n_free_p=n_free_p)
 
 
     def get_best_fit_value(self, pname, return_hesse=False):
@@ -244,11 +249,14 @@ class Minimizer(object):
         """Plot best-fit PX vs data."""
 
         # obtain dictionary of best-fit parameters (will minimize if needed)
-        best_fit_params = self.get_best_fit_params(add_fixed_params=True)
+        params = self.get_best_fit_params()
+
+        # add fixed parameters in the posterior
+        params.update(self.post.fixed_params)
 
         # use plotting tool in likelihood object to plot data and theory
         self.post.like.plot_px(
-            params=best_fit_params,
+            params=params,
             every_other_theta=every_other_theta,
             multiply_by_k=multiply_by_k,
             xlim=xlim,
@@ -281,6 +289,8 @@ class Minimizer(object):
                 rms = par.gauss_prior_width
                 info += ' (prior = {:.4f} +/- {:.4f})'.format(mean, rms)
             print(info)
+        for key, val in self.post.fixed_params.items():
+            print('{} = {:.4f} (fixed)'.format(key, val)
 
 
     def get_results_dict(self):

--- a/cupix/likelihood/minimize_posterior.py
+++ b/cupix/likelihood/minimize_posterior.py
@@ -290,7 +290,7 @@ class Minimizer(object):
                 info += ' (prior = {:.4f} +/- {:.4f})'.format(mean, rms)
             print(info)
         for key, val in self.post.fixed_params.items():
-            print('{} = {:.4f} (fixed)'.format(key, val)
+            print('{} = {:.4f} (fixed)'.format(key, val))
 
 
     def get_results_dict(self):

--- a/cupix/likelihood/posterior.py
+++ b/cupix/likelihood/posterior.py
@@ -12,13 +12,19 @@ class Posterior(object):
     ):
         """Setup posterior from likelihood and free parameters. Inputs:
         - like (required): Likelihood class 
-        - free_params (required): list LikelihoodParameter to vary
+        - free_params (required): list of FreeParameter objects to vary
         - config (optional): dictionary with different settings
         """
 
         self.verbose = config.get('verbose', False)
         self.like = like
+        # this is a list of FreeParameter objects
         self.free_params = free_params
+        # this (if provided) is a dictionary
+        self.fixed_params = config.get('fixed_params', {})
+        if self.verbose and self.fixed_params:
+            for key, value in self.fixed_params.items():
+                print('{} parameter fixed to {:.4f}'.format(key, value))
  
 
     def silence(self):
@@ -36,49 +42,53 @@ class Posterior(object):
         return ndata-npar
 
 
-    def get_log_posterior(self, params={}):
+    def get_log_like_from_values(self, values):
 
-        # check parameter bounds
-        for name,value in params.items():
-            ip = self.get_param_index(param_name=name)
-            if self.free_params[ip].out_of_bounds(value):
-                return --np.inf
+        # get dictionary with free and fixed parameters
+        params = self.get_params_from_values(values, add_fixed_params=True)
 
-        # ask likelihood to evalute log-like
+        # ask for likelihood (including also fixed_params)
         log_like = self.like.get_log_like(params=params)
 
-        # ask for prior
-        log_prior = self.get_log_prior(params=params)
-        
+        if self.verbose:
+            print('params =', params)
+            print('log like =', log_like)
+
+        return log_like
+
+
+    def get_log_posterior_from_values(self, values):
+
+        # start by computing the prior contribution
+        log_prior = self.get_log_prior_from_values(values)
+
+        # compute the likelihood (including fixed params)
+        log_like = self.get_log_like_from_values(values)
+
         # add both
         log_posterior = log_like + log_prior
 
         if self.verbose:
-            print('params =', params)
+            print('values =', values)
             print('log_like, prior, post =', log_like, log_prior, log_posterior)
 
         return log_posterior
 
 
-    def get_log_posterior_from_values(self, values):
+    def get_log_prior_from_values(self, values):
 
-        # convert values array to dictionary of parameters
-        params = self.get_params_from_values(values)
-
-        # compute log posterior using values array
-        log_posterior = self.get_log_posterior(params)
-
-        return log_posterior
-
-
-    def get_log_prior(self, params={}):
+        Np = len(self.free_params)
+        assert len(values) == Np, "Inconsistent number of free parameters"
 
         # collect priors from each parameter (no correlation)
         chi2_prior = 0.0
 
-        for name,value in params.items():
-            ip = self.get_param_index(param_name=name)
-            chi2_prior += self.free_params[ip].get_prior_chi2(value)
+        for ip, par in enumerate(self.free_params):
+            # check parameter bounds
+            if par.out_of_bounds(values[ip]):
+                return -np.inf
+            # if within bounds, add prior chi2
+            chi2_prior += par.get_prior_chi2(values[ip])
 
         log_prior = -0.5 * chi2_prior
 
@@ -93,15 +103,31 @@ class Posterior(object):
         return ipar
 
 
-    def get_params_from_values(self, values):
+    def get_free_params_from_values(self, values):
+        """Collect dictionary of parameters using input values
+        for free parameters, and fixed_params dictionary"""
+
+        return self.get_params_from_values(values, add_fixed_params=False)
+
+
+    def get_params_from_values(self, values, add_fixed_params):
+        """Collect dictionary of parameters using input values
+        for free parameters, and fixed_params dictionary"""
 
         Np = len(self.free_params)
         assert len(values) == Np, "Inconsistent number of free parameters"
 
+        # start by adding free params from values array
         params = {}
         for ip in range(Np):
             name = self.free_params[ip].name
             params[name] = values[ip]
+
+        # add fixed params (if any)
+        if add_fixed_params:
+            for key, value in self.fixed_params.items():
+                assert key not in params, key + ' both free and fixed'
+                params[key] = value
 
         return params
 

--- a/cupix/likelihood/posterior.py
+++ b/cupix/likelihood/posterior.py
@@ -18,14 +18,19 @@ class Posterior(object):
 
         self.verbose = config.get('verbose', False)
         self.like = like
+
         # this is a list of FreeParameter objects
         self.free_params = free_params
+
         # this (if provided) is a dictionary
         self.fixed_params = config.get('fixed_params', {})
-        if self.verbose and self.fixed_params:
+        if self.fixed_params:
+            free_par_names = [
             for key, value in self.fixed_params.items():
-                print('{} parameter fixed to {:.4f}'.format(key, value))
- 
+                assert key not in self.free_params, key + ' both free and fixed'
+                if self.verbose:
+                    print('{} parameter fixed to {:.4f}'.format(key, value))
+
 
     def silence(self):
         """set verbose=False in all classes"""
@@ -44,8 +49,11 @@ class Posterior(object):
 
     def get_log_like_from_values(self, values):
 
-        # get dictionary with free and fixed parameters
-        params = self.get_params_from_values(values, add_fixed_params=True)
+        # get dictionary with free parameters
+        params = self.get_params_from_values(values)
+
+        # include also fixed parameters
+        params.update(self.fixed_params)
 
         # ask for likelihood (including also fixed_params)
         log_like = self.like.get_log_like(params=params)
@@ -103,31 +111,16 @@ class Posterior(object):
         return ipar
 
 
-    def get_free_params_from_values(self, values):
-        """Collect dictionary of parameters using input values
-        for free parameters, and fixed_params dictionary"""
-
-        return self.get_params_from_values(values, add_fixed_params=False)
-
-
-    def get_params_from_values(self, values, add_fixed_params):
-        """Collect dictionary of parameters using input values
-        for free parameters, and fixed_params dictionary"""
+    def get_params_from_values(self, values):
+        """Collect dictionary of parameters using input values"""
 
         Np = len(self.free_params)
         assert len(values) == Np, "Inconsistent number of free parameters"
 
-        # start by adding free params from values array
         params = {}
         for ip in range(Np):
             name = self.free_params[ip].name
             params[name] = values[ip]
-
-        # add fixed params (if any)
-        if add_fixed_params:
-            for key, value in self.fixed_params.items():
-                assert key not in params, key + ' both free and fixed'
-                params[key] = value
 
         return params
 

--- a/cupix/likelihood/posterior.py
+++ b/cupix/likelihood/posterior.py
@@ -25,11 +25,8 @@ class Posterior(object):
         # this (if provided) is a dictionary
         self.fixed_params = config.get('fixed_params', {})
         if self.fixed_params:
-            free_par_names = [
-            for key, value in self.fixed_params.items():
-                assert key not in self.free_params, key + ' both free and fixed'
-                if self.verbose:
-                    print('{} parameter fixed to {:.4f}'.format(key, value))
+            for par in self.free_params:
+                assert par.name not in self.fixed_params, par.name+' both fixed and free'
 
 
     def silence(self):

--- a/notebooks/examples/test_posterior.py
+++ b/notebooks/examples/test_posterior.py
@@ -156,7 +156,7 @@ mini.silence()
 mini.minimize()
 
 # %%
-best_params = mini.get_best_fit_params(add_fixed_params=True)
+best_params = mini.get_best_fit_params()
 print(best_params)
 best_chi2 = like.get_chi2(params=best_params)
 print(best_chi2)
@@ -184,5 +184,9 @@ post_ns.fixed_params['nrun'] = -0.01
 
 # %%
 post_ns.get_log_posterior_from_values(values=ini_values)
+
+# %%
+
+# %%
 
 # %%

--- a/notebooks/examples/test_posterior.py
+++ b/notebooks/examples/test_posterior.py
@@ -83,8 +83,8 @@ like.get_chi2()
 
 # %%
 # start a bit off
-ini_bias = 1.05 * true_lya_params['bias']
-ini_beta = 0.9 * true_lya_params['beta']
+ini_bias = 1.01 * true_lya_params['bias']
+ini_beta = 0.98 * true_lya_params['beta']
 
 # %%
 # set the likelihood parameters as the Arinyo params with some fiducial values
@@ -119,10 +119,11 @@ for par in free_params:
 post = Posterior(like, free_params, config={'verbose': True})
 
 # %%
-test = post.get_log_posterior()
+ini_values = [par.ini_value for par in free_params]
+post.get_log_posterior_from_values(values=ini_values)
 
 # %%
-post.get_log_prior()
+post.get_log_prior_from_values(values=ini_values)
 
 # %% [markdown]
 # ### Step 4: Setup posterior minimizer
@@ -133,7 +134,8 @@ mini = Minimizer(post, config={'verbose':True})
 # %%
 true_params = {'bias': bias.true_value, 'beta': beta.true_value}
 true_chi2 = post.like.get_chi2(params=true_params)
-true_post = post.get_log_posterior(params=true_params)
+true_values = [true_params[par.name] for par in post.free_params] 
+true_post = post.get_log_posterior_from_values(values=true_values)
 print(true_chi2, true_post, -0.5*true_chi2)
 
 # %%
@@ -145,7 +147,7 @@ plt.axvline(x=beta.true_value, color='gray', ls=':')
 
 # %%
 betas = np.linspace(beta.true_value-0.1, beta.true_value+0.1, 11)
-log_post = [post.get_log_posterior(params={'bias': bias.true_value, 'beta': val}) for val in betas]
+log_post = [post.get_log_posterior_from_values(values=[bias.true_value, val]) for val in betas]
 plt.plot(betas, log_post)
 plt.axvline(x=beta.true_value, color='gray', ls=':')
 
@@ -154,7 +156,7 @@ mini.silence()
 mini.minimize()
 
 # %%
-best_params = mini.get_best_fit_params()
+best_params = mini.get_best_fit_params(add_fixed_params=True)
 print(best_params)
 best_chi2 = like.get_chi2(params=best_params)
 print(best_chi2)
@@ -162,5 +164,25 @@ print(best_chi2)
 # %%
 # these should not agree perfectly, since our prior is a bit off
 mini.plot_ellipses('bias','beta', true_vals=true_params)
+
+# %% [markdown]
+# ### Test option to specify fixed parameters
+
+# %%
+post_ns = Posterior(like, free_params, config={'verbose': True, 'fixed_params': {'ns': 0.98} })
+
+# %%
+post_ns.get_log_posterior_from_values(values=ini_values)
+
+# %%
+post.verbose = True
+post.get_log_posterior_from_values(values=ini_values)
+
+# %%
+# modify the fixed parameters of an existing posterior
+post_ns.fixed_params['nrun'] = -0.01 
+
+# %%
+post_ns.get_log_posterior_from_values(values=ini_values)
 
 # %%


### PR DESCRIPTION
Added option to specify fixed parameters in the posterior class. 

When we ask the likelihood class for the likelihood of a given model, we now pass both fixed and free parameters.

We do so by calling get_params_from_values, that now asks you to specify whether you want to include or not fixed parameters in the returning dictionary.

I keep thinking that we need a better way to differentiate a dictionary of parameters (we often call it params) from a list of Free Parameters (we call it free_params in the Posterior class). 

Let's discuss in person.